### PR TITLE
Increasing lease parameter from 1 hour to 1 week to prevent Harvester nodes from losing IP

### DIFF
--- a/modules/harvester/deployment-script/qemu_vlan1_xml.tpl
+++ b/modules/harvester/deployment-script/qemu_vlan1_xml.tpl
@@ -4,7 +4,9 @@
   <forward mode="nat"/>
   <ip address="192.168.122.1" netmask="255.255.255.0">
     <dhcp>
-      <range start="192.168.122.2" end="192.168.122.254"/>
+      <range start="192.168.122.2" end="192.168.122.254">
+        <lease expiry='168' unit='hours'/>
+      </range>
       <bootp file="http://192.168.122.1/default.ipxe"/>
     </dhcp>
   </ip>

--- a/modules/harvester/deployment-script/qemu_vlanx_xml.tpl
+++ b/modules/harvester/deployment-script/qemu_vlanx_xml.tpl
@@ -4,7 +4,9 @@
   <forward mode="nat"/>
   <ip address="${ip_base}.1" netmask="255.255.255.0">
     <dhcp>
-      <range start="${ip_base}.2" end="${ip_base}.254"/>
+      <range start="${ip_base}.2" end="${ip_base}.254">
+        <lease expiry='168' unit='hours'/>
+      </range>
     </dhcp>
   </ip>
 </network>


### PR DESCRIPTION
Hello team, 

I have been working on the issue https://github.com/rancher/harvester-cloud/issues/72 and I realized that, by default, network definitions through virsh will have 1 hour lease time for the IP assignments which means that if we shutdown a Harvester node for more than 1 hour we won't be able to recover the node as it will probably receive another IP.

With the current changes the IPs will be preserved during 1 week.

```console
node-demo-digitalocean-1:~ # virsh net-dhcp-leases vlan1
 Expiry Time           MAC address         Protocol   IP address           Hostname              Client ID or DUID
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 2025-09-16 08:55:40   52:54:00:34:bc:68   ipv4       192.168.122.216/24   -                     01:52:54:00:34:bc:68
 2025-09-16 08:55:55   52:54:00:34:bc:68   ipv4       192.168.122.217/24   -                     ff:00:34:bc:68:00:01:00:01:30:52:a8:18:52:54:00:34:bc:68
 2025-09-16 09:03:54   52:54:00:34:bc:68   ipv4       192.168.122.218/24   demo-digitalocean-2   ff:00:34:bc:68:00:01:00:01:30:52:a8:2a:52:54:00:34:bc:68
 2025-09-16 08:55:11   52:54:00:43:b2:69   ipv4       192.168.122.142/24   -                     01:52:54:00:43:b2:69
 2025-09-16 08:55:26   52:54:00:43:b2:69   ipv4       192.168.122.143/24   -                     ff:00:43:b2:69:00:01:00:01:30:52:a7:fa:52:54:00:43:b2:69
 2025-09-16 09:03:15   52:54:00:43:b2:69   ipv4       192.168.122.144/24   demo-digitalocean-1   ff:00:43:b2:69:00:01:00:01:30:52:a8:0d:52:54:00:43:b2:69
 2025-09-16 08:56:10   52:54:00:8f:b8:ab   ipv4       192.168.122.113/24   -                     01:52:54:00:8f:b8:ab
 2025-09-16 08:56:26   52:54:00:8f:b8:ab   ipv4       192.168.122.114/24   -                     ff:00:8f:b8:ab:00:01:00:01:30:52:a8:36:52:54:00:8f:b8:ab
 2025-09-16 09:04:05   52:54:00:8f:b8:ab   ipv4       192.168.122.115/24   demo-digitalocean-3   ff:00:8f:b8:ab:00:01:00:01:30:52:a8:49:52:54:00:8f:b8:ab

```

This is how it was shown before without the lease configuration on the network definition.

```console
node-demo-digitalocean-1:~ # date
Tue Sep  9 09:38:51 UTC 2025
node-demo-digitalocean-1:~ # virsh net-dhcp-leases vlan1
 Expiry Time           MAC address         Protocol   IP address           Hostname              Client ID or DUID
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 2025-09-09 10:38:01   52:54:00:63:93:3a   ipv4       192.168.122.251/24   -                     01:52:54:00:63:93:3a
 2025-09-09 10:38:16   52:54:00:63:93:3a   ipv4       192.168.122.252/24   -                     ff:00:63:93:3a:00:01:00:01:30:52:b2:05:52:54:00:63:93:3a
 2025-09-09 10:38:35   52:54:00:63:93:3a   ipv4       192.168.122.253/24   demo-digitalocean-3   ff:00:63:93:3a:00:01:00:01:30:52:b2:17:52:54:00:63:93:3a
 2025-09-09 10:37:02   52:54:00:ab:78:74   ipv4       192.168.122.196/24   -                     01:52:54:00:ab:78:74
 2025-09-09 10:37:17   52:54:00:ab:78:74   ipv4       192.168.122.197/24   -                     ff:00:ab:78:74:00:01:00:01:30:52:b1:c9:52:54:00:ab:78:74
 2025-09-09 10:37:35   52:54:00:ab:78:74   ipv4       192.168.122.198/24   demo-digitalocean-1   ff:00:ab:78:74:00:01:00:01:30:52:b1:db:52:54:00:ab:78:74
 2025-09-09 10:37:31   52:54:00:ea:62:1b   ipv4       192.168.122.220/24   -                     01:52:54:00:ea:62:1b
 2025-09-09 10:37:47   52:54:00:ea:62:1b   ipv4       192.168.122.221/24   -                     ff:00:ea:62:1b:00:01:00:01:30:52:b1:e7:52:54:00:ea:62:1b
 2025-09-09 10:38:05   52:54:00:ea:62:1b   ipv4       192.168.122.222/24   demo-digitalocean-2   ff:00:ea:62:1b:00:01:00:01:30:52:b1:fa:52:54:00:ea:62:1b


```