### PR TITLE
2026/Q1 Review - Updated several Terraform providers and brought the default Harvester version to 1.7.0.

### DIFF
--- a/modules/digitalocean/droplet/docs.md
+++ b/modules/digitalocean/droplet/docs.md
@@ -29,6 +29,7 @@ No modules.
 | [digitalocean_volume_attachment.data_disk_attachment](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/volume_attachment) | resource |
 | [local_file.private_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.public_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [null_resource.kernel_configuration](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.startup_configuration](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [tls_private_key.ssh_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [digitalocean_image.opensuse](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/image) | data source |

--- a/projects/azure/docs.md
+++ b/projects/azure/docs.md
@@ -2,10 +2,10 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.50.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.38.0 |
-| <a name="requirement_rancher2"></a> [rancher2](#requirement\_rancher2) | 8.2.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 4.58.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.0.1 |
+| <a name="requirement_rancher2"></a> [rancher2](#requirement\_rancher2) | 13.1.4 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.7.0 |
 
 ## Providers
@@ -14,7 +14,7 @@
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 8.2.1 |
+| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 13.1.4 |
 | <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
 
 ## Modules
@@ -36,7 +36,7 @@
 | [null_resource.copy_files_to_first_node](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_iso_download_checking](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_node_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [rancher2_cluster.rancher_cluster](https://registry.terraform.io/providers/rancher/rancher2/8.2.1/docs/resources/cluster) | resource |
+| [rancher2_cluster.rancher_cluster](https://registry.terraform.io/providers/rancher/rancher2/13.1.4/docs/resources/cluster) | resource |
 | [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.7.0/docs/resources/resource) | resource |
 | [local_file.sles_startup_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
@@ -55,7 +55,7 @@
 | <a name="input_harvester_first_node_token"></a> [harvester\_first\_node\_token](#input\_harvester\_first\_node\_token) | Specifies the token used to join additional nodes to the Harvester cluster (HA setup). Default is 'SecretToken.123'. | `string` | `"SecretToken.123"` | no |
 | <a name="input_harvester_node_count"></a> [harvester\_node\_count](#input\_harvester\_node\_count) | Specifies the number of Harvester nodes to create (1, 3, or 5). Default is '1'. | `number` | `1` | no |
 | <a name="input_harvester_password"></a> [harvester\_password](#input\_harvester\_password) | Specifies the password used to access the Harvester nodes. Default is 'SecretPassword.123'. | `string` | `"SecretPassword.123"` | no |
-| <a name="input_harvester_version"></a> [harvester\_version](#input\_harvester\_version) | Specifies the Harvester version. Default is 'v1.6.1'. | `string` | `"v1.6.1"` | no |
+| <a name="input_harvester_version"></a> [harvester\_version](#input\_harvester\_version) | Specifies the Harvester version. Default is 'v1.7.0'. | `string` | `"v1.7.0"` | no |
 | <a name="input_ip_cidr_range"></a> [ip\_cidr\_range](#input\_ip\_cidr\_range) | Specifies the range of private IPs available for the Azure Subnet. Default is '10.10.0.0/24'. | `string` | `"10.10.0.0/24"` | no |
 | <a name="input_os_disk_size"></a> [os\_disk\_size](#input\_os\_disk\_size) | Specifies the size of the disk attached to each node, in GB. Default is '50'. | `number` | `50` | no |
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | Specifies the type of the disk attached to each node ('Standard\_LRS, 'StandardSSD\_LRS', 'Premium\_LRS' or 'UltraSSD\_LRS'). Default is 'Premium\_LRS'. | `string` | `"Premium_LRS"` | no |

--- a/projects/azure/providers.tf
+++ b/projects/azure/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.50.0"
+      version = "4.58.0"
     }
     ssh = {
       source  = "loafoe/ssh"
@@ -10,15 +10,15 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.38.0"
+      version = "3.0.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "3.1.0"
+      version = "3.1.1"
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = "8.2.1"
+      version = "13.1.4"
     }
   }
 }

--- a/projects/azure/terraform.tfvars.example
+++ b/projects/azure/terraform.tfvars.example
@@ -44,7 +44,7 @@ data_disk_size = 350
 startup_script = null
 
 ## -- Specifies the Harvester version.
-harvester_version = "v1.6.1"
+harvester_version = "v1.7.0"
 
 ## -- Specifies the number of Harvester nodes to create (1, 3, or 5).
 harvester_node_count = 1

--- a/projects/azure/variables.tf
+++ b/projects/azure/variables.tf
@@ -167,9 +167,9 @@ variable "startup_script" {
 }
 
 variable "harvester_version" {
-  description = "Specifies the Harvester version. Default is 'v1.6.1'."
+  description = "Specifies the Harvester version. Default is 'v1.7.0'."
   type        = string
-  default     = "v1.6.1"
+  default     = "v1.7.0"
   validation {
     condition     = can(regex("^v.*$", var.harvester_version))
     error_message = "The Harvester version must start with 'v' (e.g., v1.4.1, v1.4.2-rc2, v1.5.0-dev-20250217)."

--- a/projects/digitalocean/docs.md
+++ b/projects/digitalocean/docs.md
@@ -2,10 +2,10 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | 2.68.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.38.0 |
-| <a name="requirement_rancher2"></a> [rancher2](#requirement\_rancher2) | 8.2.1 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | 2.75.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.0.1 |
+| <a name="requirement_rancher2"></a> [rancher2](#requirement\_rancher2) | 13.1.4 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.7.0 |
 
 ## Providers
@@ -14,7 +14,7 @@
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 8.2.1 |
+| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 13.1.4 |
 | <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
 
 ## Modules
@@ -36,7 +36,7 @@
 | [null_resource.copy_files_to_first_node](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_iso_download_checking](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_node_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [rancher2_cluster.rancher_cluster](https://registry.terraform.io/providers/rancher/rancher2/8.2.1/docs/resources/cluster) | resource |
+| [rancher2_cluster.rancher_cluster](https://registry.terraform.io/providers/rancher/rancher2/13.1.4/docs/resources/cluster) | resource |
 | [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.7.0/docs/resources/resource) | resource |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
@@ -55,7 +55,7 @@
 | <a name="input_harvester_first_node_token"></a> [harvester\_first\_node\_token](#input\_harvester\_first\_node\_token) | Specifies the token used to join additional nodes to the Harvester cluster (HA setup). Default is 'SecretToken.123'. | `string` | `"SecretToken.123"` | no |
 | <a name="input_harvester_node_count"></a> [harvester\_node\_count](#input\_harvester\_node\_count) | Specifies the number of Harvester nodes to create (1, 3, or 5). Default is '1'. | `number` | `1` | no |
 | <a name="input_harvester_password"></a> [harvester\_password](#input\_harvester\_password) | Specifies the password used to access the Harvester nodes. Default is 'SecretPassword.123'. | `string` | `"SecretPassword.123"` | no |
-| <a name="input_harvester_version"></a> [harvester\_version](#input\_harvester\_version) | Specifies the Harvester version. Default is 'v1.6.1'. | `string` | `"v1.6.1"` | no |
+| <a name="input_harvester_version"></a> [harvester\_version](#input\_harvester\_version) | Specifies the Harvester version. Default is 'v1.7.0'. | `string` | `"v1.7.0"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Specifies the name of the DigitalOcean Droplet type. Default is 'g-16vcpu-64gb'. | `string` | `"g-16vcpu-64gb"` | no |
 | <a name="input_os_image_name"></a> [os\_image\_name](#input\_os\_image\_name) | Specifies the name of the OpenSUSE image uploaded to the DigitalOcean account. Default is 'openSUSE-Leap-15.6'. | `string` | `"openSUSE-Leap-15.6"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'do-tf'. | `string` | `"do-tf"` | no |

--- a/projects/digitalocean/providers.tf
+++ b/projects/digitalocean/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.68.0"
+      version = "2.75.0"
     }
     ssh = {
       source  = "loafoe/ssh"
@@ -10,15 +10,15 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.38.0"
+      version = "3.0.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "3.1.0"
+      version = "3.1.1"
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = "8.2.1"
+      version = "13.1.4"
     }
   }
 }

--- a/projects/digitalocean/terraform.tfvars.example
+++ b/projects/digitalocean/terraform.tfvars.example
@@ -38,7 +38,7 @@ data_disk_size = 350
 startup_script = null
 
 ## -- Specifies the Harvester version.
-harvester_version = "v1.6.1"
+harvester_version = "v1.7.0"
 
 ## -- Specifies the number of Harvester nodes to create (1, 3, or 5).
 harvester_node_count = 1

--- a/projects/digitalocean/variables.tf
+++ b/projects/digitalocean/variables.tf
@@ -111,9 +111,9 @@ variable "startup_script" {
 }
 
 variable "harvester_version" {
-  description = "Specifies the Harvester version. Default is 'v1.6.1'."
+  description = "Specifies the Harvester version. Default is 'v1.7.0'."
   type        = string
-  default     = "v1.6.1"
+  default     = "v1.7.0"
   validation {
     condition     = can(regex("^v.*$", var.harvester_version))
     error_message = "The Harvester version must start with 'v' (e.g., v1.4.1, v1.4.2-rc2, v1.5.0-dev-20250217)."

--- a/projects/google-cloud/docs.md
+++ b/projects/google-cloud/docs.md
@@ -2,10 +2,10 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_google"></a> [google](#requirement\_google) | 7.9.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.38.0 |
-| <a name="requirement_rancher2"></a> [rancher2](#requirement\_rancher2) | 8.2.1 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 7.17.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 3.1.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 3.0.1 |
+| <a name="requirement_rancher2"></a> [rancher2](#requirement\_rancher2) | 13.1.4 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.7.0 |
 
 ## Providers
@@ -14,7 +14,7 @@
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
-| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 8.2.1 |
+| <a name="provider_rancher2"></a> [rancher2](#provider\_rancher2) | 13.1.4 |
 | <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
 
 ## Modules
@@ -36,7 +36,7 @@
 | [null_resource.copy_files_to_first_node](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_iso_download_checking](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_node_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [rancher2_cluster.rancher_cluster](https://registry.terraform.io/providers/rancher/rancher2/8.2.1/docs/resources/cluster) | resource |
+| [rancher2_cluster.rancher_cluster](https://registry.terraform.io/providers/rancher/rancher2/13.1.4/docs/resources/cluster) | resource |
 | [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.7.0/docs/resources/resource) | resource |
 | [local_file.sles_startup_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
@@ -56,7 +56,7 @@
 | <a name="input_harvester_first_node_token"></a> [harvester\_first\_node\_token](#input\_harvester\_first\_node\_token) | Specifies the token used to join additional nodes to the Harvester cluster (HA setup). Default is 'SecretToken.123'. | `string` | `"SecretToken.123"` | no |
 | <a name="input_harvester_node_count"></a> [harvester\_node\_count](#input\_harvester\_node\_count) | Specifies the number of Harvester nodes to create (1, 3, or 5). Default is '1'. | `number` | `1` | no |
 | <a name="input_harvester_password"></a> [harvester\_password](#input\_harvester\_password) | Specifies the password used to access the Harvester nodes. Default is 'SecretPassword.123'. | `string` | `"SecretPassword.123"` | no |
-| <a name="input_harvester_version"></a> [harvester\_version](#input\_harvester\_version) | Specifies the Harvester version. Default is 'v1.6.1'. | `string` | `"v1.6.1"` | no |
+| <a name="input_harvester_version"></a> [harvester\_version](#input\_harvester\_version) | Specifies the Harvester version. Default is 'v1.7.0'. | `string` | `"v1.7.0"` | no |
 | <a name="input_ip_cidr_range"></a> [ip\_cidr\_range](#input\_ip\_cidr\_range) | Specifies the range of private IPs available for the Google Subnet. Default is '10.10.0.0/24'. | `string` | `"10.10.0.0/24"` | no |
 | <a name="input_os_disk_size"></a> [os\_disk\_size](#input\_os\_disk\_size) | Specifies the size of the disk attached to each node, in GB. Default is '50'. | `number` | `50` | no |
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | Specifies the type of the disk attached to each node (e.g., 'pd-standard', 'pd-ssd', or 'pd-balanced'). Default is 'pd-ssd'. | `string` | `"pd-ssd"` | no |

--- a/projects/google-cloud/providers.tf
+++ b/projects/google-cloud/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.9.0"
+      version = "7.17.0"
     }
     ssh = {
       source  = "loafoe/ssh"
@@ -10,15 +10,15 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.38.0"
+      version = "3.0.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "3.1.0"
+      version = "3.1.1"
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = "8.2.1"
+      version = "13.1.4"
     }
   }
 }

--- a/projects/google-cloud/terraform.tfvars.example
+++ b/projects/google-cloud/terraform.tfvars.example
@@ -53,7 +53,7 @@ data_disk_size = 350
 startup_script = null
 
 ## -- Specifies the Harvester version.
-harvester_version = "v1.6.1"
+harvester_version = "v1.7.0"
 
 ## -- Specifies the number of Harvester nodes to create (1, 3, or 5).
 harvester_node_count = 1

--- a/projects/google-cloud/variables.tf
+++ b/projects/google-cloud/variables.tf
@@ -163,9 +163,9 @@ variable "startup_script" {
 }
 
 variable "harvester_version" {
-  description = "Specifies the Harvester version. Default is 'v1.6.1'."
+  description = "Specifies the Harvester version. Default is 'v1.7.0'."
   type        = string
-  default     = "v1.6.1"
+  default     = "v1.7.0"
   validation {
     condition     = can(regex("^v.*$", var.harvester_version))
     error_message = "The Harvester version must start with 'v' (e.g., v1.4.1, v1.4.2-rc2, v1.5.0-dev-20250217)."


### PR DESCRIPTION
#138 

Tested on all cloud providers.