### PR TITLE
Fixing test_aws_cloud infra pipeline

### DIFF
--- a/.github/workflows/test-aws-cloud-infra-only.yaml
+++ b/.github/workflows/test-aws-cloud-infra-only.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Get public IP from Terraform output
         id: ip
         run: |
-          ip=$(terraform output -json first_instance_public_ip | jq -r '.[0]')
+          ip=$(terraform output -json first_instance_public_ip | jq -r '.')
           echo "INSTANCE_IP=$ip" >> $GITHUB_ENV
         working-directory: tests/aws/infra-only
       - name: Wait for SSH (port 22) to become available


### PR DESCRIPTION
Fix the command to retrieve the public IP from Terraform output.

https://github.com/rancher/harvester-cloud/issues/163