### PR TITLE
Updated terraform.tfvars.example to fix the cluster_network_vlan_nics

### DIFF
--- a/projects/harvester-ops/network-creation/terraform.tfvars.example
+++ b/projects/harvester-ops/network-creation/terraform.tfvars.example
@@ -11,7 +11,7 @@ cluster_network_name = "cluster-vlan"
 cluster_network_vlanconfig_name = "cluster-vlan-all-nodes"
 
 ## -- Specifies the list of NICs used for the Harvester Cluster Network VLAN.
-cluster_network_vlan_nics = "virbr2"
+cluster_network_vlan_nics = ["virbr2"]  
 
 ## -- Specifies the bond mode for the Harvester Cluster Network VLAN.
 cluster_network_vlan_bond_mode = "active-backup"


### PR DESCRIPTION
When using the default terraform.tfvars.example, it uses a string type in the variables.tf.

I was getting an error when using the default value in terraform.tfvars.example:
~~~
Plan: 8 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid value for input variable
│ 
│   on terraform.tfvars line 14:
│   14: cluster_network_vlan_nics = "virbr2"
│ 
│ The given value is not suitable for var.cluster_network_vlan_nics declared at variables.tf:25,1-37: list of any single type required.
╵
~~~