### PR TITLE
Fix/issue 204

### DIFF
--- a/.github/workflows/test-aws-cloud-infra-only.yaml
+++ b/.github/workflows/test-aws-cloud-infra-only.yaml
@@ -22,11 +22,17 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+      - name: Get public IP from the GitHub Runner (security purpose)
+        id: get_ip
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "Detected GitHub Runner IP: $RUNNER_IP"
       - name: Initialize Terraform
         run: terraform init
         working-directory: tests/aws/infra-only
       - name: Run Terraform apply
-        run: terraform apply -auto-approve
+        run: terraform apply -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/aws/infra-only
       - name: Get public IP from Terraform output
         id: ip
@@ -51,5 +57,5 @@ jobs:
           INSTANCE_IP: ${{ env.INSTANCE_IP }}
       - name: Run Terraform Destroy
         if: always()
-        run: terraform destroy -auto-approve
+        run: terraform destroy -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/aws/infra-only

--- a/.github/workflows/test-azure-infra-only.yaml
+++ b/.github/workflows/test-azure-infra-only.yaml
@@ -20,13 +20,19 @@ jobs:
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
+      - name: Get public IP from the GitHub Runner (security purpose)
+        id: get_ip
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "Detected GitHub Runner IP: $RUNNER_IP"
       - name: Initialize Terraform
         run: terraform init
         working-directory: tests/azure/infra-only
       - name: Run Terraform apply
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        run: terraform apply -var "subscription_id=$AZURE_SUBSCRIPTION_ID" -auto-approve
+        run: terraform apply -var "subscription_id=$AZURE_SUBSCRIPTION_ID" -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/azure/infra-only
       - name: Get public IP from Terraform output
         id: ip
@@ -53,5 +59,5 @@ jobs:
         if: always()
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        run: terraform destroy -var "subscription_id=$AZURE_SUBSCRIPTION_ID" -auto-approve
+        run: terraform destroy -var "subscription_id=$AZURE_SUBSCRIPTION_ID" -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/azure/infra-only

--- a/.github/workflows/test-digitalocean-infra-only.yaml
+++ b/.github/workflows/test-digitalocean-infra-only.yaml
@@ -16,13 +16,19 @@ jobs:
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: "1.14.6"
+      - name: Get public IP from the GitHub Runner (security purpose)
+        id: get_ip
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "Detected GitHub Runner IP: $RUNNER_IP"
       - name: Initialize Terraform
         run: terraform init
         working-directory: tests/digitalocean/infra-only
       - name: Run Terraform apply
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
-        run: terraform apply -var "do_token=$DIGITALOCEAN_TOKEN" -auto-approve
+        run: terraform apply -var "do_token=$DIGITALOCEAN_TOKEN" -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/digitalocean/infra-only
       - name: Get public IP from Terraform output
         id: ip
@@ -49,5 +55,5 @@ jobs:
         if: always()
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
-        run: terraform destroy -var "do_token=$DIGITALOCEAN_TOKEN" -auto-approve
+        run: terraform destroy -var "do_token=$DIGITALOCEAN_TOKEN" -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/digitalocean/infra-only

--- a/.github/workflows/test-google-cloud-infra-only.yaml
+++ b/.github/workflows/test-google-cloud-infra-only.yaml
@@ -20,13 +20,19 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Get public IP from the GitHub Runner (security purpose)
+        id: get_ip
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "Detected GitHub Runner IP: $RUNNER_IP"
       - name: Initialize Terraform
         run: terraform init
         working-directory: tests/google-cloud/infra-only
       - name: Run Terraform apply
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-        run: terraform apply -var "project_id=$GCP_PROJECT_ID" -auto-approve
+        run: terraform apply -var "project_id=$GCP_PROJECT_ID" -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/google-cloud/infra-only
       - name: Get public IP from Terraform output
         id: ip
@@ -53,5 +59,5 @@ jobs:
         if: always()
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-        run: terraform destroy -var "project_id=$GCP_PROJECT_ID" -auto-approve
+        run: terraform destroy -var "project_id=$GCP_PROJECT_ID" -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" -auto-approve
         working-directory: tests/google-cloud/infra-only

--- a/.github/workflows/test-rancher-integration.yaml
+++ b/.github/workflows/test-rancher-integration.yaml
@@ -37,6 +37,7 @@ jobs:
           terraform apply -auto-approve \
             -var "prefix=rancher-harv-integration-wf" \
             -var "project_id=$PROJECT_ID" \
+            -var "region=europe-west3" \
             -var "rancher_password=$RANCHER_PASSWORD"
         working-directory: tf-rancher-up/recipes/upstream/google-cloud/rke2
       - name: Get Rancher endpoint from Terraform output

--- a/.github/workflows/test-rancher-integration.yaml
+++ b/.github/workflows/test-rancher-integration.yaml
@@ -20,6 +20,12 @@ jobs:
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+      - name: Get public IP from the GitHub Runner (security purpose)
+        id: get_ip
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+          echo "Detected GitHub Runner IP: $RUNNER_IP"
       - name: Initialize Terraform (Rancher - tf-rancher-up project)
         run: terraform init
         working-directory: tf-rancher-up/recipes/upstream/google-cloud/rke2
@@ -136,6 +142,7 @@ jobs:
           terraform apply -auto-approve \
             -var "prefix=harv-rancher-integration-wf" \
             -var "project_id=$GCP_PROJECT_ID" \
+            -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" \
             -var "rancher_api_url=$RANCHER_URL" \
             -var "rancher_access_key=$RANCHER_CI_TOKEN_ACCESS_KEY" \
             -var "rancher_secret_key=$RANCHER_CI_TOKEN_SECRET_KEY" \
@@ -213,6 +220,7 @@ jobs:
           terraform destroy -auto-approve \
             -var "prefix=harv-rancher-integration-wf" \
             -var "project_id=$GCP_PROJECT_ID" \
+            -var "public_ip_source_addresses=[\"$RUNNER_IP/32\"]" \
             -var "rancher_api_url=$RANCHER_URL" \
             -var "rancher_access_key=$RANCHER_CI_TOKEN_ACCESS_KEY" \
             -var "rancher_secret_key=$RANCHER_CI_TOKEN_SECRET_KEY" \

--- a/tests/aws/infra-only/docs.md
+++ b/tests/aws/infra-only/docs.md
@@ -23,6 +23,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_public_ip_source_addresses"></a> [public\_ip\_source\_addresses](#input\_public\_ip\_source\_addresses) | Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level). | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/tests/aws/infra-only/main.tf
+++ b/tests/aws/infra-only/main.tf
@@ -6,10 +6,11 @@ locals {
 }
 
 module "harvester_node" {
-  source               = "../../../modules/aws/ec2"
-  prefix               = var.prefix
-  region               = local.region
-  ssh_private_key_path = local.ssh_private_key_path
-  ssh_public_key_path  = local.ssh_public_key_path
-  instance_type        = local.instance_type
+  source                     = "../../../modules/aws/ec2"
+  prefix                     = var.prefix
+  region                     = local.region
+  ssh_private_key_path       = local.ssh_private_key_path
+  ssh_public_key_path        = local.ssh_public_key_path
+  instance_type              = local.instance_type
+  public_ip_source_addresses = var.public_ip_source_addresses
 }

--- a/tests/aws/infra-only/variables.tf
+++ b/tests/aws/infra-only/variables.tf
@@ -3,3 +3,16 @@ variable "prefix" {
   type        = string
   default     = "harvcloudinfratest"
 }
+
+variable "public_ip_source_addresses" {
+  description = "Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level)."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for cidr in var.public_ip_source_addresses :
+      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}\\/([0-9]|[12][0-9]|3[0-2])$", cidr))
+    ])
+    error_message = "Each value must be in CIDR format (A.B.C.D/N), e.g. [\"203.0.113.10/32\", \"198.51.100.0/24\"]."
+  }
+}

--- a/tests/azure/infra-only/docs.md
+++ b/tests/azure/infra-only/docs.md
@@ -22,8 +22,9 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'harv-cloud-infra-test'. | `string` | `"harvcloudinfratest"` | no |
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Specifies the Azure Subscription ID that will contain all created resources. Default is 'harv-cloud-infra-test'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_public_ip_source_addresses"></a> [public\_ip\_source\_addresses](#input\_public\_ip\_source\_addresses) | Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level). | `list(string)` | `[]` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Specifies the Azure Subscription ID that will contain all created resources. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
 
 ## Outputs
 

--- a/tests/azure/infra-only/main.tf
+++ b/tests/azure/infra-only/main.tf
@@ -6,10 +6,11 @@ locals {
 }
 
 module "harvester_node" {
-  source               = "../../../modules/azure/virtual-machine"
-  prefix               = var.prefix
-  region               = local.region
-  ssh_private_key_path = local.ssh_private_key_path
-  ssh_public_key_path  = local.ssh_public_key_path
-  instance_type        = local.instance_type
+  source                     = "../../../modules/azure/virtual-machine"
+  prefix                     = var.prefix
+  region                     = local.region
+  ssh_private_key_path       = local.ssh_private_key_path
+  ssh_public_key_path        = local.ssh_public_key_path
+  instance_type              = local.instance_type
+  public_ip_source_addresses = var.public_ip_source_addresses
 }

--- a/tests/azure/infra-only/variables.tf
+++ b/tests/azure/infra-only/variables.tf
@@ -9,3 +9,16 @@ variable "subscription_id" {
   type        = string
   default     = "harvcloudinfratest"
 }
+
+variable "public_ip_source_addresses" {
+  description = "Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level)."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for cidr in var.public_ip_source_addresses :
+      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}\\/([0-9]|[12][0-9]|3[0-2])$", cidr))
+    ])
+    error_message = "Each value must be in CIDR format (A.B.C.D/N), e.g. [\"203.0.113.10/32\", \"198.51.100.0/24\"]."
+  }
+}

--- a/tests/digitalocean/infra-only/docs.md
+++ b/tests/digitalocean/infra-only/docs.md
@@ -22,8 +22,9 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean API token used to deploy the infrastructure. Default is 'harv-cloud-infra-test'. | `string` | `"harvcloudinfratest"` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'harv-cloud-infra-test'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean API token used to deploy the infrastructure. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_public_ip_source_addresses"></a> [public\_ip\_source\_addresses](#input\_public\_ip\_source\_addresses) | Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level). | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/tests/digitalocean/infra-only/main.tf
+++ b/tests/digitalocean/infra-only/main.tf
@@ -6,10 +6,11 @@ locals {
 }
 
 module "harvester_node" {
-  source               = "../../../modules/digitalocean/droplet"
-  prefix               = var.prefix
-  region               = local.region
-  ssh_private_key_path = local.ssh_private_key_path
-  ssh_public_key_path  = local.ssh_public_key_path
-  instance_type        = local.instance_type
+  source                     = "../../../modules/digitalocean/droplet"
+  prefix                     = var.prefix
+  region                     = local.region
+  ssh_private_key_path       = local.ssh_private_key_path
+  ssh_public_key_path        = local.ssh_public_key_path
+  instance_type              = local.instance_type
+  public_ip_source_addresses = var.public_ip_source_addresses
 }

--- a/tests/digitalocean/infra-only/variables.tf
+++ b/tests/digitalocean/infra-only/variables.tf
@@ -9,3 +9,16 @@ variable "do_token" {
   type        = string
   default     = "harvcloudinfratest"
 }
+
+variable "public_ip_source_addresses" {
+  description = "Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level)."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for cidr in var.public_ip_source_addresses :
+      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}\\/([0-9]|[12][0-9]|3[0-2])$", cidr))
+    ])
+    error_message = "Each value must be in CIDR format (A.B.C.D/N), e.g. [\"203.0.113.10/32\", \"198.51.100.0/24\"]."
+  }
+}

--- a/tests/google-cloud/infra-only/docs.md
+++ b/tests/google-cloud/infra-only/docs.md
@@ -24,6 +24,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Specifies the prefix added to the names of all resources. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Specifies the Google Project ID that will contain all created resources. Default is 'harvcloudinfratest'. | `string` | `"harvcloudinfratest"` | no |
+| <a name="input_public_ip_source_addresses"></a> [public\_ip\_source\_addresses](#input\_public\_ip\_source\_addresses) | Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level). | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/tests/google-cloud/infra-only/main.tf
+++ b/tests/google-cloud/infra-only/main.tf
@@ -6,10 +6,11 @@ locals {
 }
 
 module "harvester_node" {
-  source               = "../../../modules/google-cloud/compute-engine"
-  prefix               = var.prefix
-  region               = local.region
-  ssh_private_key_path = local.ssh_private_key_path
-  ssh_public_key_path  = local.ssh_public_key_path
-  instance_type        = local.instance_type
+  source                     = "../../../modules/google-cloud/compute-engine"
+  prefix                     = var.prefix
+  region                     = local.region
+  ssh_private_key_path       = local.ssh_private_key_path
+  ssh_public_key_path        = local.ssh_public_key_path
+  instance_type              = local.instance_type
+  public_ip_source_addresses = var.public_ip_source_addresses
 }

--- a/tests/google-cloud/infra-only/variables.tf
+++ b/tests/google-cloud/infra-only/variables.tf
@@ -9,3 +9,16 @@ variable "project_id" {
   type        = string
   default     = "harvcloudinfratest"
 }
+
+variable "public_ip_source_addresses" {
+  description = "Specifies a list of CIDR blocks allowed to access port 22 (SSH). Default is an empty list (no restrictions defined at variable level)."
+  type        = list(string)
+  default     = []
+  validation {
+    condition = alltrue([
+      for cidr in var.public_ip_source_addresses :
+      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}\\/([0-9]|[12][0-9]|3[0-2])$", cidr))
+    ])
+    error_message = "Each value must be in CIDR format (A.B.C.D/N), e.g. [\"203.0.113.10/32\", \"198.51.100.0/24\"]."
+  }
+}


### PR DESCRIPTION
In the test pipelines below, after deploying the VM to the cloud, we tried connecting via ssh (port 22).
With the new security policy, where VMs can only be accessed from the console running the Terraform code, this connection failed.
I solved the problem by taking the GH Runner's public IP and passing it as an apply/destroy variable.

TEST done --> https://github.com/rancher/harvester-cloud/actions

Thanks @devenkulkarni for the heads up! :) 